### PR TITLE
Track mortality

### DIFF
--- a/src/soar_lib/Decision.h
+++ b/src/soar_lib/Decision.h
@@ -169,13 +169,17 @@ public:
 	 * \return True if succesfull, else loading error
 	 */
 	bool LoadFromFile(char *filename);
-	///@} End of group started by \name
-
-
+	///@} End of group started by \name	
+	
 	/// \name Statistics output
 	/// @{ 
 	/// \brief Saves the summary statistics into an ascii file
 	void SaveSummaryStatisticsToFile(char *filename);
+	
+	/// \name Saving of mortality patterns
+	/// @{
+	/// \brief Saves mortality patterns (predation, disease, starvation) into an ascii file after each iteration.
+	bool SaveMortalityPatternsToFile(char *filename);
 
 	/// \brief Prints a summary to the console 
 	void PrintSummary();

--- a/src/soar_lib/Forward.cpp
+++ b/src/soar_lib/Forward.cpp
@@ -683,7 +683,7 @@ double Forward::ComputePopulationDynamics(Settings *settings) {
 	//---------------------------------------
 	// allocate state array for storing proportions
 
-	NArray<double> FW_props_renorm, FW_props, FW_old;
+	NArray<double> FW_props_renorm, FW_props, FW_old, FW_predation, FW_disease, FW_starvation;
 	FW_props.Init(_x_cnt, _y_cnt, _e_cnt, _a_cnt, _o_cnt, _s_cnt, _t_cnt);
 	FW_old.Init(_x_cnt, _y_cnt, _e_cnt, _a_cnt, _o_cnt, _s_cnt, _t_cnt);
 	FW_props_renorm.Init(_x_cnt, _y_cnt, _e_cnt, _a_cnt, _o_cnt, _s_cnt, _t_cnt);

--- a/src/soar_lib/Forward.cpp
+++ b/src/soar_lib/Forward.cpp
@@ -512,6 +512,8 @@ void Forward::Init(Settings *settings)
 	_conv.fw_convergence = false;
 
 	_user_init_start_pop = settings->GetUserInitStartPop();  
+	_save_mortality_pattern_each_cycle = settings->GetSaveMortalityPatternEachCycle();
+	_save_final_mortality_pattern      = settings->GetSaveFinalMortalityPattern();
 	_n_fw                = settings->GetNFW();
 	_n_min_fw            = settings->GetNMinFW();
 	_start_week_fw       = settings->GetStartWeekFW();

--- a/src/soar_lib/Forward.cpp
+++ b/src/soar_lib/Forward.cpp
@@ -81,6 +81,33 @@ void   Forward::SavePopulationDynamics(char *filename)
 	fclose(file);
 }
 
+void   Forward::SaveMortalityPatterns(char *filename)
+{
+	if (_FW_predation.GetSize()==0)  {
+		printf("Forward::SaveMortalityPatterns(%s) error. Size of predation array equals zero.");
+		return;
+	}
+	if (_FW_disease.GetSize()==0)  {
+		printf("Forward::SaveMortalityPatterns(%s) error. Size of disease array equals zero.");
+		return;
+	}
+	if (_FW_starvation.GetSize()==0)  {
+		printf("Forward::SaveMortalityPatterns(%s) error. Size of starvation array equals zero.");
+		return;
+	}
+
+	FILE *file = fopen(filename,"wb");
+	if (file==0) {
+		printf("Forward::SaveMortalityPatterns(%s) error opening the file for writing\n",filename);
+		return;
+	}    
+
+	_FW_predation.SaveBinary(file);
+	_FW_disease.SaveBinary(file);
+	_FW_starvation.SaveBinary(file);			
+
+	fclose(file);
+}
 
 bool Forward::LoadFwFromFile(char *filename) 
 {

--- a/src/soar_lib/Forward.h
+++ b/src/soar_lib/Forward.h
@@ -94,7 +94,10 @@ private:
 
 	char            _filename_fw_pd[FILENAME_MAX];  // PopulationDynamics
 	char            _filename_fw_pd_year[FILENAME_MAX];	// Population dynamics in a single year
+	char		_filename_fw_mp_year[FILENAME_MAX]; // Mortality patterns in a single year
 	bool            _user_init_start_pop;
+	bool		_save_mortality_pattern_each_cycle;
+	bool		_save_final_mortality_pattern;
 	double          _lambda_fw_average;
 	double          _fw_convergence; 
 	bool            _fw_year_conv; 
@@ -155,6 +158,9 @@ private:
     };
 
 	NArray<double>     _FW_props;	
+	NArray<double>     _FW_predation;
+	NArray<double>     _FW_disease;
+	NArray<double>     _FW_starvation;
 	FwConvResultStruct _conv;
 
 	void Stoch_HMcN_AddStochNone (double x_case, double y_case, FwStochXYPropResultStruct &cases);
@@ -177,7 +183,7 @@ private:
 	}
 
     void CalcLambdaAndConvergence(NArray<double> &FW_props, NArray<double> &FW_old ,FwConvResultStruct & result);
-	void CalcLambdaAndConvergence_Toekoelyi(NArray<double> &FW_props, NArray<double> &FW_old ,FwConvResultStruct & result);
+    void CalcLambdaAndConvergence_Toekoelyi(NArray<double> &FW_props, NArray<double> &FW_old ,FwConvResultStruct & result);
         
     double Rand01(void);
 	bool IsNumber(double);
@@ -196,6 +202,7 @@ public:
 
     double ComputePopulationDynamics(Settings *settings);   
     void   SavePopulationDynamics(char *filename); 
+    void   SaveMortalityPatterns(char *filename);
 
 	// -------- NEW (start) ----------------------------------
 	/**

--- a/src/soar_lib/Settings.cpp
+++ b/src/soar_lib/Settings.cpp
@@ -37,7 +37,9 @@ Settings::Settings() {
 	// ======== General settings ======== 
 	_pm.Add(_run_backward,         "RunBackward");
 	_pm.Add(_run_forward,          "RunForward");
-	_pm.Add(_user_init_start_pop,  "UserdefinedInitializationOfStartPopulation", true);	
+	_pm.Add(_user_init_start_pop,  "UserdefinedInitializationOfStartPopulation", true);
+	_pm.Add(_save_mortality_pattern_each_cycle, "SaveMortalityPatternEachCycle", true);
+	_pm.Add(_save_final_mortality_pattern,      "SaveFinalMortalityPattern", true);
 	_pm.Add(_enable_migration,     "EnableMigrationOption");
 	_pm.Add(_enable_health_dim,    "EnableHealthDimension");
 
@@ -143,6 +145,8 @@ Settings::Settings() {
 	// - FuncTypes are automatically instantiated to FT_NONE 
 	// - NArrays are empty.
 	_user_init_start_pop   = false;
+	_save_mortality_pattern_each_cycle = false;
+	_save_final_mortality_pattern      = false;
 	_y_min                 = -1;
 	_y_max                 = -1;
 	_grid_y                = 0;

--- a/src/soar_lib/Settings.h
+++ b/src/soar_lib/Settings.h
@@ -59,7 +59,9 @@ private:
 	/// @{ 
 	bool     _run_forward;         ///< Run forward simulation
 	bool     _run_backward;        ///< Run backward simulation
-	bool     _user_init_start_pop; ///< User-defined initialization of start population NEW
+	bool     _user_init_start_pop; ///< User-defined initialization of start population
+	bool     _save_mortality_pattern_each_cycle; ///< Save yearly mortality pattern
+	bool     _save_final_mortality_pattern;      ///< Save final mortality pattern
 	bool     _enable_migration;    ///< Enable migration option
 	bool     _enable_health_dim;   ///< Enable health dimension
 	bool     _calibrate_theta;     ///< Backward calibrate theta
@@ -194,6 +196,8 @@ public:
 	/// \name Setters
 	/// @{ 
 	void SetUserInitStartPop(bool userinitstartpop)  { _user_init_start_pop; } 
+	void SetSaveMortalityPatternEachCycle(bool savemortalitypatterneachcycle) { _save_mortality_pattern_each_cycle; }
+	void SetSaveFinalMortalityPattern(bool savefinalmortalitypattern) { _save_final_mortality_pattern; }
 	void SetN(unsigned int n)			{ _n = n; }                 ///< Set number of years for backward computation
 	void SetNMin(unsigned int nmin)     { _n_min = nmin; }
     void SetNFW(unsigned int n)		    { _n_fw = n; }              ///< Set number of years for forward computation
@@ -258,23 +262,25 @@ public:
 	/// @{ 
 	bool   GetRunForward()		      { return _run_forward;  }
 	bool   GetRunBackward()		      { return _run_backward; }
-	bool   GetUserInitStartPop()      { return _user_init_start_pop; } 
+	bool   GetUserInitStartPop()          { return _user_init_start_pop; } 
+	bool   GetSaveMortalityPatternEachCycle() { return _save_mortality_pattern_each_cycle; }
+	bool   GetSaveFinalMortalityPattern()     { return _save_final_mortality_pattern; }
 	bool   GetEnableMigration()       { return _enable_migration; }
 	bool   GetEnableHealthDim()       { return _enable_health_dim; }
 
-	unsigned int GetN()				  { return _n; }
-	unsigned int GetNMin()			  { return _n_min; }
-	char  *GetFilePrefix()		      { return _file_prefix; }
+	unsigned int GetN()		  { return _n; }
+	unsigned int GetNMin()		  { return _n_min; }
+	char  *GetFilePrefix()		  { return _file_prefix; }
 	bool   GetCalibrateTheta()        { return _calibrate_theta; }
 	double GetCalibrationThetaMin()   { return _calibrate_theta_min; }
 
-    unsigned int GetNFW()			   { return _n_fw; }
+        unsigned int GetNFW()			   { return _n_fw; }
 	unsigned int GetNMinFW()		   { return _n_min_fw; }	
 	char        *GetFilePrefixFW()	   { return _file_prefix_fw; }
-    unsigned int GetStartWeekFW()      { return _start_week_fw; }
+        unsigned int GetStartWeekFW()      { return _start_week_fw; }
 	unsigned int GetStartLocationFW()  { return _start_loc_fw; }
 
-    unsigned int GetTCnt()		{ return _t_cnt; }
+        unsigned int GetTCnt()		{ return _t_cnt; }
 	unsigned int GetGridX()		{ return _grid_x; }
 	unsigned int GetGridY()		{ return _grid_y; }
 
@@ -282,10 +288,10 @@ public:
 	double	GetXMax()			{ return _x_max; }
 	double	GetYMin()			{ return _y_min; }
 	double	GetYMax()			{ return _y_max; }
-    double	GetDx()             { return _dx; }
-    double	GetDy()             { return _dy; }
-    unsigned int GetXCnt()		{ return _x_cnt; }
-    unsigned int GetYCnt()		{ return _y_cnt; }
+   	double	GetDx()             { return _dx; }
+  	double	GetDy()             { return _dy; }
+    	unsigned int GetXCnt()		{ return _x_cnt; }
+   	unsigned int GetYCnt()		{ return _y_cnt; }
 
 
     double	GetXindep()         { return _x_indep; }


### PR DESCRIPTION
Merging version "trackMortality" into master. "trackMortality"  allows tracking and storing of mortality patterns (predation/disease/starvation) as binary files either in each cycle or at the end of all cycles through two user-defined boolean parameters in the configuration file.